### PR TITLE
Füge HTTPS-Unterstützung hinzu

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -1,5 +1,18 @@
 const http = require("http");
+const https = require("https");
+
+const fs = require("fs");
+const path = require("path");
 
 const app = require("./app");
 
-const httpServer = http.createServer(app).listen(80);
+// HTTP Server
+http.createServer(app).listen(80);
+
+// HTTPS Server
+const options = {
+  key: fs.readFileSync(path.resolve(__dirname, "../certificates/site/site.key.pem")),
+  cert: fs.readFileSync(path.resolve(__dirname, "../certificates/site/site.cert.pem"))
+};
+
+https.createServer(options, app).listen(443);


### PR DESCRIPTION
Der Server nimmt das Zertifikat und den Schlüssel aus dem `certificates/site`-Ordner